### PR TITLE
copy task: easier destination paths

### DIFF
--- a/gulpfile.js/config.js
+++ b/gulpfile.js/config.js
@@ -33,25 +33,24 @@ const config = {
 
     // Copy
     // copy assets from source to app
-    // watch out: path for destinationFolder is built relative from sourceFolder!
     'copy': [
         {
             'title': 'SVGs',
             'sourceFolder': './source/templates/svg',
             'sourceFiles': ['*.svg'],
-            'destinationFolder': '../../../app/assets/svg'
+            'destinationFolder': './app/assets/svg'
         },
         {
             'title': 'Material Icons',
             'sourceFolder': './node_modules/material-design-icons/iconfont',
             'sourceFiles': ['*.{woff,woff2}'],
-            'destinationFolder': '../../../app/assets/fonts'
+            'destinationFolder': './app/assets/fonts'
         },
         {
             'title': 'Bootstrap icons',
             'sourceFolder': './node_modules/bootstrap-sass/assets/fonts/bootstrap',
             'sourceFiles': ['*.{woff,woff2}'],
-            'destinationFolder': '../../../../../app/assets/fonts/bootstrap'
+            'destinationFolder': './app/assets/fonts/bootstrap'
         }
     ],
 

--- a/gulpfile.js/tasks/copy.js
+++ b/gulpfile.js/tasks/copy.js
@@ -2,6 +2,7 @@ const gulp = require('gulp');
 const log = require('fancy-log');
 const colors = require('ansi-colors');
 const copy = require('cpy');
+const path = require('path');
 const pSeries = require('p-series');
 const _ = require('lodash');
 
@@ -13,7 +14,7 @@ const task = (cb) => {
     let tasks = [];
     // loop through copy tasks (see config) and fill an array with results from copy functions (promises!)
     _.forEach(config.copy, function (v) {
-        tasks.push(() => copy(v.sourceFiles, v.destinationFolder, {
+        tasks.push(() => copy(v.sourceFiles, path.resolve(v.destinationFolder), {
             cwd: v.sourceFolder,
             parents: true,
             nodir: true


### PR DESCRIPTION
We can avoid these relative paths by giving an absolute path to `copy()`, generated by `path.resolve()`.